### PR TITLE
Improve switching between DP and divide-and-conquer method

### DIFF
--- a/fast_poibin/pmf.py
+++ b/fast_poibin/pmf.py
@@ -92,6 +92,11 @@ def calc_pmf(probabilities: FloatSequence, dp_step: int = DP_STEP) -> npt.NDArra
     Space comlexity: O(N)
     """
     size = len(probabilities)
+    # Just performing DP is usually better than convolving an array of dp_step length and
+    # another short one, though this idea should further be refined.
+    if size < dp_step * 2:
+        res: npt.NDArray[np.float64] = calc_pmf_dp(np.array(probabilities, np.float64))
+        return res
     if dp_step > 0:
         # FIXME: Is min() really necessary?
         # FIXME: I copy the returned values of calc_pmf_dp here, because they are sometimes
@@ -121,7 +126,7 @@ def calc_pmf(probabilities: FloatSequence, dp_step: int = DP_STEP) -> npt.NDArra
 
     if not polynomials:
         return np.array((1.0,), np.float64)
-    res: npt.NDArray[np.float64] = polynomials[0]
+    res = polynomials[0]
     res.resize(size + 1, refcheck=False)
     return np.maximum(res, 0.0)
 

--- a/fast_poibin/pmf.py
+++ b/fast_poibin/pmf.py
@@ -79,7 +79,7 @@ DP_STEP = 255
 
 
 # FIXME: This type definition is a compromise.
-# 1. np.ndarray is not Sequence. I couldn't find an appropriate iterable type that
+# 1. 1D np.ndarray is not Sequence. I couldn't find an appropriate iterable type that
 # contains np.ndarray.
 # 2. I'm not sure whether np.floating[Any] is a decent type for generic float.
 FloatSequence = Union[Sequence[float], npt.NDArray[np.floating[Any]]]

--- a/fast_poibin/pmf.py
+++ b/fast_poibin/pmf.py
@@ -92,8 +92,6 @@ def calc_pmf(probabilities: FloatSequence, dp_step: int = DP_STEP) -> npt.NDArra
     Space comlexity: O(N)
     """
     size = len(probabilities)
-    if size == 0:
-        return np.array([1.0], dtype=np.float64)
     if dp_step > 1:
         # FIXME: Is min() really necessary?
         # FIXME: I copy the returned values of calc_pmf_dp here, because they are sometimes
@@ -120,6 +118,9 @@ def calc_pmf(probabilities: FloatSequence, dp_step: int = DP_STEP) -> npt.NDArra
     while len(polynomials) > 1:
         it = iter(polynomials)
         polynomials = [_convolve(p1, p2) for p1, p2 in zip_longest(it, it)]
+
+    if not polynomials:
+        return np.array([1.0], np.float64)
     res: npt.NDArray[np.float64] = polynomials[0]
     res.resize(size + 1, refcheck=False)
     return np.maximum(res, 0.0)

--- a/fast_poibin/pmf.py
+++ b/fast_poibin/pmf.py
@@ -92,7 +92,7 @@ def calc_pmf(probabilities: FloatSequence, dp_step: int = DP_STEP) -> npt.NDArra
     Space comlexity: O(N)
     """
     size = len(probabilities)
-    if dp_step > 1:
+    if dp_step > 0:
         # FIXME: Is min() really necessary?
         # FIXME: I copy the returned values of calc_pmf_dp here, because they are sometimes
         # just a view of another array, which can't be resized.

--- a/fast_poibin/pmf.py
+++ b/fast_poibin/pmf.py
@@ -15,7 +15,7 @@ def convolve(
     vector1: npt.NDArray[np.float64], vector2: npt.NDArray[np.float64]
 ) -> npt.NDArray[np.float64]:
     if vector1.size == 0 or vector2.size == 0:
-        return np.array([], dtype=np.float64)
+        return np.array((), dtype=np.float64)
     prod_size = vector1.size + vector2.size - 1
     fft_size = power_of_two_ceil(prod_size) * 2
     res = np.fft.irfft(np.fft.rfft(vector1, fft_size) * np.fft.rfft(vector2, fft_size), fft_size)
@@ -120,7 +120,7 @@ def calc_pmf(probabilities: FloatSequence, dp_step: int = DP_STEP) -> npt.NDArra
         polynomials = [_convolve(p1, p2) for p1, p2 in zip_longest(it, it)]
 
     if not polynomials:
-        return np.array([1.0], np.float64)
+        return np.array((1.0,), np.float64)
     res: npt.NDArray[np.float64] = polynomials[0]
     res.resize(size + 1, refcheck=False)
     return np.maximum(res, 0.0)

--- a/tests/test_pmf.py
+++ b/tests/test_pmf.py
@@ -4,6 +4,7 @@ import numpy as np
 import numpy.testing as nptest
 
 from fast_poibin.pmf import (
+    DP_STEP,
     FFT_THRESHOLD,
     calc_pmf,
     calc_pmf_dp,
@@ -65,7 +66,7 @@ def test_calc_pmf_small_handmade_case() -> None:
     # (0.9 + 0.1x)(0.8 + 0.2x)^3(0.3+0.7x)
     # = 0.00056 x^5 + 0.012 x^4 + 0.0924 x^3 + 0.3152 x^2 + 0.4416 x + 0.13824
     # (By WolframAlpha)
-    for step in [0, 2, 8, 32, 64]:
+    for step in range(10):
         nptest.assert_allclose(
             calc_pmf(probs, step),
             [0.13824, 0.4416, 0.3152, 0.0924, 0.012, 0.00056],
@@ -74,14 +75,15 @@ def test_calc_pmf_small_handmade_case() -> None:
 
 def test_calc_pmf_dp_coincide_with_calc_pmf_fft() -> None:
     rng = np.random.default_rng(2235)
-    for size, step in product(list(range(10)) + [10, 20, 29, 41, 51], [0, 2, 8, 32, 64]):
+    for size, step in product(list(range(10)) + [10, 20, 29, 41, 51], [0, 1, 2, 3, 30, DP_STEP]):
         for _ in range(50):
             probs = rng.random(size, np.float64)
             nptest.assert_allclose(calc_pmf(probs, step), calc_pmf_dp(probs), rtol=1e-9, atol=1e-9)
 
-    # larger instance
-    for size, step in product([2000], [0, 64]):
-        assert size >= FFT_THRESHOLD
+    # sufficiently large instance so that FFT is used
+    size = 2001
+    assert size >= FFT_THRESHOLD
+    for step in [0, 10, DP_STEP]:
         for _ in range(10):
             probs = rng.random(size, np.float64)
             nptest.assert_allclose(calc_pmf(probs, step), calc_pmf_dp(probs), rtol=1e-9, atol=1e-9)
@@ -97,13 +99,13 @@ def test_calc_pmf_fft_non_negativity() -> None:
 
 
 def test_calc_pmf_non_float64_ndarray() -> None:
-    for step in [0, 4]:
+    for step in range(10):
         assert calc_pmf(np.array([0.1, 0.2, 0.3], np.float16), step).dtype == np.float64
         assert calc_pmf(np.array([0.1, 0.2, 0.3], np.float32), step).dtype == np.float64
 
 
 def test_calc_pmf_non_ndarray() -> None:
-    for step in [0, 4]:
+    for step in range(10):
         assert calc_pmf([0, 1, 0, 0, 1], step).dtype == np.float64
         assert calc_pmf([0.1, 0.2, 0.1, 0.2, 0.3], step).dtype == np.float64
 

--- a/tests/test_pmf.py
+++ b/tests/test_pmf.py
@@ -108,19 +108,19 @@ def test_calc_pmf_non_ndarray() -> None:
         assert calc_pmf([0.1, 0.2, 0.1, 0.2, 0.3], step).dtype == np.float64
 
 
-def test_calc_pmf_zero() -> None:
-    for step in [0, 1, 2, 4, 8]:
+def test_calc_pmf_empty_array() -> None:
+    for step in [0, 1, 2, 4, 500, 1000, 1023, 1024, 1025, 10000]:
         nptest.assert_array_equal(calc_pmf([], step), [1.0])
 
 
-def test_calc_pmf_dp_zero() -> None:
+def test_calc_pmf_dp_empty_array() -> None:
     nptest.assert_array_equal(calc_pmf_dp(np.array([])), [1.0])
 
 
-def test_calc_pmf_one() -> None:
-    for step in [0, 1, 2, 4, 8]:
+def test_calc_pmf_single_element() -> None:
+    for step in [0, 1, 2, 4, 500, 1000, 1023, 1024, 1025, 10000]:
         nptest.assert_array_equal(calc_pmf([0.3], step), [0.7, 0.3])
 
 
-def test_calc_pmf_dp_one() -> None:
+def test_calc_pmf_dp_single_element() -> None:
     nptest.assert_array_equal(calc_pmf_dp(np.array([0.3])), [0.7, 0.3])

--- a/tests/test_pmf.py
+++ b/tests/test_pmf.py
@@ -65,30 +65,26 @@ def test_calc_pmf_small_handmade_case() -> None:
     # (0.9 + 0.1x)(0.8 + 0.2x)^3(0.3+0.7x)
     # = 0.00056 x^5 + 0.012 x^4 + 0.0924 x^3 + 0.3152 x^2 + 0.4416 x + 0.13824
     # (By WolframAlpha)
-    for threshold in [0, 2, 8, 32, 64]:
+    for step in [0, 2, 8, 32, 64]:
         nptest.assert_allclose(
-            calc_pmf(probs, threshold),
+            calc_pmf(probs, step),
             [0.13824, 0.4416, 0.3152, 0.0924, 0.012, 0.00056],
         )
 
 
 def test_calc_pmf_dp_coincide_with_calc_pmf_fft() -> None:
     rng = np.random.default_rng(2235)
-    for size, threshold in product(list(range(10)) + [10, 20, 29, 41, 51], [0, 2, 8, 32, 64]):
+    for size, step in product(list(range(10)) + [10, 20, 29, 41, 51], [0, 2, 8, 32, 64]):
         for _ in range(50):
             probs = rng.random(size, np.float64)
-            nptest.assert_allclose(
-                calc_pmf(probs, threshold), calc_pmf_dp(probs), rtol=1e-9, atol=1e-9
-            )
+            nptest.assert_allclose(calc_pmf(probs, step), calc_pmf_dp(probs), rtol=1e-9, atol=1e-9)
 
     # larger instance
-    for size, threshold in product([2000], [0, 64]):
+    for size, step in product([2000], [0, 64]):
         assert size >= FFT_THRESHOLD
         for _ in range(10):
             probs = rng.random(size, np.float64)
-            nptest.assert_allclose(
-                calc_pmf(probs, threshold), calc_pmf_dp(probs), rtol=1e-9, atol=1e-9
-            )
+            nptest.assert_allclose(calc_pmf(probs, step), calc_pmf_dp(probs), rtol=1e-9, atol=1e-9)
 
 
 def test_calc_pmf_fft_non_negativity() -> None:
@@ -101,20 +97,20 @@ def test_calc_pmf_fft_non_negativity() -> None:
 
 
 def test_calc_pmf_non_float64_ndarray() -> None:
-    for threshold in [0, 4]:
-        assert calc_pmf(np.array([0.1, 0.2, 0.3], np.float16), threshold).dtype == np.float64
-        assert calc_pmf(np.array([0.1, 0.2, 0.3], np.float32), threshold).dtype == np.float64
+    for step in [0, 4]:
+        assert calc_pmf(np.array([0.1, 0.2, 0.3], np.float16), step).dtype == np.float64
+        assert calc_pmf(np.array([0.1, 0.2, 0.3], np.float32), step).dtype == np.float64
 
 
 def test_calc_pmf_non_ndarray() -> None:
-    for threshold in [0, 4]:
-        assert calc_pmf([0, 1, 0, 0, 1], threshold).dtype == np.float64
-        assert calc_pmf([0.1, 0.2, 0.1, 0.2, 0.3], threshold).dtype == np.float64
+    for step in [0, 4]:
+        assert calc_pmf([0, 1, 0, 0, 1], step).dtype == np.float64
+        assert calc_pmf([0.1, 0.2, 0.1, 0.2, 0.3], step).dtype == np.float64
 
 
 def test_calc_pmf_zero() -> None:
-    for threshold in [0, 1, 2, 4, 8]:
-        nptest.assert_array_equal(calc_pmf([], threshold), [1.0])
+    for step in [0, 1, 2, 4, 8]:
+        nptest.assert_array_equal(calc_pmf([], step), [1.0])
 
 
 def test_calc_pmf_dp_zero() -> None:
@@ -122,8 +118,8 @@ def test_calc_pmf_dp_zero() -> None:
 
 
 def test_calc_pmf_one() -> None:
-    for threshold in [0, 1, 2, 4, 8]:
-        nptest.assert_array_equal(calc_pmf([0.3], threshold), [0.7, 0.3])
+    for step in [0, 1, 2, 4, 8]:
+        nptest.assert_array_equal(calc_pmf([0.3], step), [0.7, 0.3])
 
 
 def test_calc_pmf_dp_one() -> None:


### PR DESCRIPTION
Close #5 

## Script

```python
import statistics
from timeit import Timer

import matplotlib.pyplot as plt
import numpy as np

from fast_poibin.pmf import calc_pmf, calc_pmf_dp

data = np.array([], np.float64)


def _timeit(stmt: str, size: int) -> float:
    rng = np.random.default_rng(321)
    global data
    data = rng.random(size)
    timer = Timer(stmt, globals=globals())
    number = timer.autorange()[0] * 2 + 1
    secs = [x / number for x in timer.repeat(repeat=5, number=number)]
    med = statistics.median(secs)
    coef_var = statistics.stdev(secs) / statistics.mean(secs)
    print(f"{size=}, {med=:.8f}, {coef_var=:.4f}, {number=}")
    return med


thresholds = [x - 1 for x in [16, 32, 64, 128, 256, 512]]
sizes = [100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600]


plt.style.use("seaborn-v0_8-whitegrid")

for threshold in thresholds:
    print(f"{threshold=}")
    secs = [_timeit(f"calc_pmf(data, {threshold})", size) for size in sizes]
    plt.plot(sizes, secs, "o-", label=f"{threshold=}")

plt.xscale("log")
plt.yscale("log")
plt.xlabel("size")
plt.ylabel("seconds")
plt.legend()
plt.savefig("dp_step.png")
```

## Result

```
threshold=15
size=100, med=0.00003604, coef_var=0.0274, number=20001
size=200, med=0.00007458, coef_var=0.0227, number=10001
size=400, med=0.00014591, coef_var=0.0434, number=4001
size=800, med=0.00030708, coef_var=0.0369, number=2001
size=1600, med=0.00069895, coef_var=0.0274, number=1001
size=3200, med=0.00160589, coef_var=0.0248, number=401
size=6400, med=0.00349977, coef_var=0.0530, number=201
size=12800, med=0.00863690, coef_var=0.0231, number=101
size=25600, med=0.02099547, coef_var=0.0273, number=41
threshold=31
size=100, med=0.00002426, coef_var=0.0491, number=20001
size=200, med=0.00004347, coef_var=0.0352, number=10001
size=400, med=0.00009016, coef_var=0.0148, number=10001
size=800, med=0.00020247, coef_var=0.0275, number=4001
size=1600, med=0.00047666, coef_var=0.0458, number=1001
size=3200, med=0.00112105, coef_var=0.0082, number=401
size=6400, med=0.00283793, coef_var=0.0483, number=201
size=12800, med=0.00613599, coef_var=0.0436, number=101
size=25600, med=0.01613130, coef_var=0.0268, number=41
threshold=63
size=100, med=0.00000439, coef_var=0.0332, number=100001
size=200, med=0.00003103, coef_var=0.0492, number=20001
size=400, med=0.00006228, coef_var=0.0100, number=10001
size=800, med=0.00014133, coef_var=0.0328, number=4001
size=1600, med=0.00037151, coef_var=0.0392, number=2001
size=3200, med=0.00094606, coef_var=0.0332, number=1001
size=6400, med=0.00225223, coef_var=0.0744, number=201
size=12800, med=0.00546027, coef_var=0.0125, number=101
size=25600, med=0.01413290, coef_var=0.0881, number=41
threshold=127
size=100, med=0.00000427, coef_var=0.0679, number=100001
size=200, med=0.00001253, coef_var=0.0308, number=40001
size=400, med=0.00005221, coef_var=0.0639, number=10001
size=800, med=0.00012483, coef_var=0.0223, number=4001
size=1600, med=0.00032925, coef_var=0.0233, number=2001
size=3200, med=0.00086887, coef_var=0.0313, number=1001
size=6400, med=0.00204499, coef_var=0.0454, number=401
size=12800, med=0.00529122, coef_var=0.0357, number=101
size=25600, med=0.01358155, coef_var=0.0517, number=41
threshold=255
size=100, med=0.00000437, coef_var=0.0292, number=100001
size=200, med=0.00001274, coef_var=0.0384, number=40001
size=400, med=0.00004397, coef_var=0.0552, number=10001
size=800, med=0.00012675, coef_var=0.0541, number=4001
size=1600, med=0.00032567, coef_var=0.0327, number=2001
size=3200, med=0.00081370, coef_var=0.0525, number=1001
size=6400, med=0.00206159, coef_var=0.0346, number=201
size=12800, med=0.00531293, coef_var=0.0564, number=101
size=25600, med=0.01294506, coef_var=0.0119, number=41
threshold=511
size=100, med=0.00000436, coef_var=0.0353, number=100001
size=200, med=0.00001274, coef_var=0.0933, number=40001
size=400, med=0.00004407, coef_var=0.0433, number=10001
size=800, med=0.00017702, coef_var=0.0303, number=4001
size=1600, med=0.00037698, coef_var=0.0496, number=2001
size=3200, med=0.00092123, coef_var=0.0259, number=1001
size=6400, med=0.00219990, coef_var=0.0259, number=201
size=12800, med=0.00566380, coef_var=0.0332, number=101
size=25600, med=0.01441009, coef_var=0.0398, number=41
```
